### PR TITLE
Fix for issue loading video on versions of NW.js >= 0.5x

### DIFF
--- a/src/VideoPlayer/video.js
+++ b/src/VideoPlayer/video.js
@@ -5,7 +5,11 @@ const loadVideo = (videoName) => {
     if (videoCache[videoName]) {
         return videoCache[videoName]
     }
-    let texture = PIXI.Texture.fromVideo(`movies/${videoName}`)
+    let video = document.createElement('video')
+    video.crossOrigin = 'anonymous'
+    video.preload = ''
+    video.src=`movies/${videoName}`
+    let texture = PIXI.Texture.fromVideo(video)
     texture.baseTexture.autoPlay = false
     videoCache[videoName] = texture
     return texture


### PR DESCRIPTION
Another dev was trying to use this plugin with an updated nw.js version (0.53.0, and also 0.50.2), the plugin wouldn't play.

The error that fired was "GL_INVALID_OPERATION: Texture level does not exist"

I followed the advice here: https://github.com/pixijs/pixi.js/issues/5996 for this patch.

This works for him now. 
There might be a more elegant way of doing this only in one of the effected versions or something. I don't have an easy way to revert my nw.js version in my install, as I've also ugpraded. I believe it should be backwards compatible though