### PR TITLE
Video respects masterVolume setting

### DIFF
--- a/src/VideoPlayer/video.js
+++ b/src/VideoPlayer/video.js
@@ -22,6 +22,7 @@ const newVideo = (videoName, id = "video") => {
 
 const playVideo = (video) => {
     SceneManager._scene._spriteset.addVideo(video)
+	video.texture.baseTexture.source.volume = AudioManager.masterVolume
     video.texture.baseTexture.source.play()
 }
 


### PR DESCRIPTION
Used YSP_VideoPlayer in a project (thanks for the hard work!) and noticed a small issue. The played video is always at 100% volume. RPG Maker MV has a variable ,AudioManager.masterVolume, that is sometimes exposed in other plugins that can be used to mute the game including its own implementation of Show Video.

The PR will bring YSP video support in line with base.